### PR TITLE
Exposed useItemPackagePreview

### DIFF
--- a/Assets/SteamVR/InteractionSystem/Core/Scripts/ItemPackageSpawner.cs
+++ b/Assets/SteamVR/InteractionSystem/Core/Scripts/ItemPackageSpawner.cs
@@ -33,6 +33,7 @@ namespace Valve.VR.InteractionSystem
 
 		public ItemPackage _itemPackage;
 
+		[SerializeField]
 		private bool useItemPackagePreview = true;
 		private bool useFadedPreview = false;
 		private GameObject previewObject;


### PR DESCRIPTION
Exposed 'useItemPackagePreview' to Editor inspector so it can be used. Otherwise, it is always true and redundant